### PR TITLE
Fix: Correct `tourney_date` casting in SQL query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,185 @@
+# Mac stuff
 .DS_Store
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+*.exe
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+
+# files downloaded by following the examples in the book
+a1/nyc-taxis/
+
+# files created by following the examples in the book
+ch02/western_europe.csv

--- a/ch06/duckdb-in-action_ch06.ipynb
+++ b/ch06/duckdb-in-action_ch06.ipynb
@@ -1,0 +1,1343 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 6. 파이썬 생태계와 통합하기"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6.1. 시작하기\n",
+    "### 6.1.1. 파이썬 패키지 설치하기\n",
+    "```\n",
+    "pip install duckdb\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:29.148380Z",
+     "start_time": "2025-04-06T08:53:29.114551Z"
+    }
+   },
+   "source": [
+    "import duckdb\n",
+    "duckdb.__version__"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1.2.1'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.1.2. 데이터베이스 연결 열기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:30.334458Z",
+     "start_time": "2025-04-06T08:53:30.257455Z"
+    }
+   },
+   "source": [
+    "result = duckdb.sql('SELECT 42')\n",
+    "result.show()"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌───────┐\n",
+      "│  42   │\n",
+      "│ int32 │\n",
+      "├───────┤\n",
+      "│    42 │\n",
+      "└───────┘\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:32.737816Z",
+     "start_time": "2025-04-06T08:53:32.724239Z"
+    }
+   },
+   "source": [
+    "result = duckdb.execute('SELECT 42')\n",
+    "row = result.fetchone()\n",
+    "print(row)"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(42,)\n"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6.2. 관계형 API 이용하기\n",
+    "### 6.2.1. 파이썬 API를 사용한 CSV 데이터 수집하기기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:35.493645Z",
+     "start_time": "2025-04-06T08:53:34.738448Z"
+    }
+   },
+   "source": [
+    "# 코드 6.1 CSV 파일 쿼리하기\n",
+    "con = duckdb.connect(database=':memory:')\n",
+    "\n",
+    "con.execute(\"INSTALL httpfs\")\n",
+    "con.execute(\"LOAD httpfs\")\n",
+    "\n",
+    "population = \\\n",
+    "  con.read_csv(\"https://bit.ly/3KoiZR0\")\n",
+    "type(population)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "duckdb.duckdb.DuckDBPyRelation"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:38.466299Z",
+     "start_time": "2025-04-06T08:53:37.797939Z"
+    }
+   },
+   "source": [
+    "con.execute(\"SELECT * from population limit 2\").fetchall()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('Afghanistan ',\n",
+       "  'ASIA (EX. NEAR EAST)         ',\n",
+       "  31056997,\n",
+       "  647500,\n",
+       "  '48,0',\n",
+       "  '0,00',\n",
+       "  '23,06',\n",
+       "  '163,07',\n",
+       "  700,\n",
+       "  '36,0',\n",
+       "  '3,2',\n",
+       "  '12,13',\n",
+       "  '0,22',\n",
+       "  '87,65',\n",
+       "  '1',\n",
+       "  '46,6',\n",
+       "  '20,34',\n",
+       "  '0,38',\n",
+       "  '0,24',\n",
+       "  '0,38'),\n",
+       " ('Albania ',\n",
+       "  'EASTERN EUROPE                     ',\n",
+       "  3581655,\n",
+       "  28748,\n",
+       "  '124,6',\n",
+       "  '1,26',\n",
+       "  '-4,93',\n",
+       "  '21,52',\n",
+       "  4500,\n",
+       "  '86,5',\n",
+       "  '71,2',\n",
+       "  '21,09',\n",
+       "  '4,42',\n",
+       "  '74,49',\n",
+       "  '3',\n",
+       "  '15,11',\n",
+       "  '5,22',\n",
+       "  '0,232',\n",
+       "  '0,188',\n",
+       "  '0,579')]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:38.998253Z",
+     "start_time": "2025-04-06T08:53:38.476297Z"
+    }
+   },
+   "source": [
+    "(population\n",
+    "    .count(\"*\")\n",
+    "    .show()\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌──────────────┐\n",
+      "│ count_star() │\n",
+      "│    int64     │\n",
+      "├──────────────┤\n",
+      "│          227 │\n",
+      "└──────────────┘\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 6
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:41.508198Z",
+     "start_time": "2025-04-06T08:53:40.841309Z"
+    }
+   },
+   "source": [
+    "population.to_table(\"population\")"
+   ],
+   "outputs": [],
+   "execution_count": 7
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:43.308436Z",
+     "start_time": "2025-04-06T08:53:43.294007Z"
+    }
+   },
+   "source": [
+    "population_table = con.table(\"population\")"
+   ],
+   "outputs": [],
+   "execution_count": 8
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:45.135062Z",
+     "start_time": "2025-04-06T08:53:45.122522Z"
+    }
+   },
+   "source": [
+    "population_table.count(\"*\").show()"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌──────────────┐\n",
+      "│ count_star() │\n",
+      "│    int64     │\n",
+      "├──────────────┤\n",
+      "│          227 │\n",
+      "└──────────────┘\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 9
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.2.2. 쿼리 구성하기기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:48.585092Z",
+     "start_time": "2025-04-06T08:53:48.571583Z"
+    }
+   },
+   "source": [
+    "(population_table\n",
+    "  .filter('Population > 10000000')\n",
+    "  .project(\"Country, Population\")\n",
+    "  .limit(5)\n",
+    "  .show()\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌──────────────┬────────────┐\n",
+      "│   Country    │ Population │\n",
+      "│   varchar    │   int64    │\n",
+      "├──────────────┼────────────┤\n",
+      "│ Afghanistan  │   31056997 │\n",
+      "│ Algeria      │   32930091 │\n",
+      "│ Angola       │   12127071 │\n",
+      "│ Argentina    │   39921833 │\n",
+      "│ Australia    │   20264082 │\n",
+      "└──────────────┴────────────┘\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 10
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:48.601178Z",
+     "start_time": "2025-04-06T08:53:48.593083Z"
+    }
+   },
+   "source": [
+    "over_10m = population_table.filter('Population > 10000000')"
+   ],
+   "outputs": [],
+   "execution_count": 11
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:52.250221Z",
+     "start_time": "2025-04-06T08:53:52.221635Z"
+    }
+   },
+   "source": [
+    "(over_10m\n",
+    "  .aggregate(\"Region, CAST(avg(Population) AS int) as pop\")\n",
+    "  .order(\"pop DESC\")\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌─────────────────────────────────────┬───────────┐\n",
+       "│               Region                │    pop    │\n",
+       "│               varchar               │   int32   │\n",
+       "├─────────────────────────────────────┼───────────┤\n",
+       "│ ASIA (EX. NEAR EAST)                │ 192779730 │\n",
+       "│ NORTHERN AMERICA                    │ 165771574 │\n",
+       "│ LATIN AMER. & CARIB                 │  48643375 │\n",
+       "│ C.W. OF IND. STATES                 │  48487549 │\n",
+       "│ WESTERN EUROPE                      │  38955933 │\n",
+       "│ NORTHERN AFRICA                     │  38808343 │\n",
+       "│ NEAR EAST                           │  32910924 │\n",
+       "│ SUB-SAHARAN AFRICA                  │  30941436 │\n",
+       "│ EASTERN EUROPE                      │  23691959 │\n",
+       "│ OCEANIA                             │  20264082 │\n",
+       "├─────────────────────────────────────┴───────────┤\n",
+       "│ 10 rows                               2 columns │\n",
+       "└─────────────────────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 12
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:52.281266Z",
+     "start_time": "2025-04-06T08:53:52.257733Z"
+    }
+   },
+   "source": [
+    "(over_10m\n",
+    "  .filter('\"GDP ($ per capita)\" > 10000')\n",
+    "  .count(\"*\")\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌──────────────┐\n",
+       "│ count_star() │\n",
+       "│    int64     │\n",
+       "├──────────────┤\n",
+       "│           20 │\n",
+       "└──────────────┘"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 13
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:53.939002Z",
+     "start_time": "2025-04-06T08:53:53.894375Z"
+    }
+   },
+   "source": [
+    "(population_table\n",
+    "  .except_(over_10m)\n",
+    "  .aggregate(\"\"\"\n",
+    "   Region,\n",
+    "   CAST(avg(population) AS int) AS population,\n",
+    "   count(*)\n",
+    "   \"\"\")\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌─────────────────────────────────────┬────────────┬──────────────┐\n",
+       "│               Region                │ population │ count_star() │\n",
+       "│               varchar               │   int32    │    int64     │\n",
+       "├─────────────────────────────────────┼────────────┼──────────────┤\n",
+       "│ OCEANIA                             │     643379 │           20 │\n",
+       "│ NEAR EAST                           │    2773978 │           11 │\n",
+       "│ C.W. OF IND. STATES                 │    5377686 │            7 │\n",
+       "│ SUB-SAHARAN AFRICA                  │    3322228 │           30 │\n",
+       "│ NORTHERN AMERICA                    │      43053 │            3 │\n",
+       "│ EASTERN EUROPE                      │    5426538 │            9 │\n",
+       "│ ASIA (EX. NEAR EAST)                │    2796374 │            9 │\n",
+       "│ LATIN AMER. & CARIB                 │    2154024 │           35 │\n",
+       "│ NORTHERN AFRICA                     │    3086881 │            2 │\n",
+       "│ BALTICS                             │    2394991 │            3 │\n",
+       "│ WESTERN EUROPE                      │    2407190 │           19 │\n",
+       "├─────────────────────────────────────┴────────────┴──────────────┤\n",
+       "│ 11 rows                                               3 columns │\n",
+       "└─────────────────────────────────────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 14
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:55.610242Z",
+     "start_time": "2025-04-06T08:53:55.594910Z"
+    }
+   },
+   "source": [
+    "eastern_europe = population_table \\\n",
+    "  .filter(\"Region ~ '.*EASTERN EUROPE.*'\")"
+   ],
+   "outputs": [],
+   "execution_count": 15
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:57.461231Z",
+     "start_time": "2025-04-06T08:53:57.431668Z"
+    }
+   },
+   "source": [
+    "(eastern_europe\n",
+    "  .intersect(over_10m)\n",
+    "  .project(\"Country, Population\")\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌─────────────────┬────────────┐\n",
+       "│     Country     │ Population │\n",
+       "│     varchar     │   int64    │\n",
+       "├─────────────────┼────────────┤\n",
+       "│ Czech Republic  │   10235455 │\n",
+       "│ Poland          │   38536869 │\n",
+       "│ Romania         │   22303552 │\n",
+       "└─────────────────┴────────────┘"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 16
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.2.3.\tSQL 쿼리하기"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:53:58.975131Z",
+     "start_time": "2025-04-06T08:53:58.961760Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT count(*)\n",
+    "FROM over_10m\n",
+    "WHERE \"GDP ($ per capita)\" > 10000\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌──────────────┐\n",
+       "│ count_star() │\n",
+       "│    int64     │\n",
+       "├──────────────┤\n",
+       "│           20 │\n",
+       "└──────────────┘"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 17
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:01.077014Z",
+     "start_time": "2025-04-06T08:54:00.658007Z"
+    }
+   },
+   "source": [
+    "con.execute(\"\"\"\n",
+    "SELECT count(*)\n",
+    "FROM over_10m\n",
+    "WHERE \"GDP ($ per capita)\" > $gdp\n",
+    "\"\"\", {\n",
+    "  \"gdp\":10000\n",
+    "}).fetchone()\n"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(20,)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 18
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6.3.\tpandas 데이터프레임 쿼리하기\n",
+    "```pip install pandas```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:02.890459Z",
+     "start_time": "2025-04-06T08:54:02.877302Z"
+    }
+   },
+   "source": [
+    "import duckdb \n",
+    "import pandas as pd"
+   ],
+   "outputs": [],
+   "execution_count": 19
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:04.451114Z",
+     "start_time": "2025-04-06T08:54:04.437439Z"
+    }
+   },
+   "source": [
+    "people = pd.DataFrame({\n",
+    "    \"name\": [\"Michael Hunger\", \"Michael Simons\", \"Mark Needham\"],\n",
+    "    \"country\": [\"Germany\", \"Germany\", \"Great Britain\"]\n",
+    "})"
+   ],
+   "outputs": [],
+   "execution_count": 20
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:06.107775Z",
+     "start_time": "2025-04-06T08:54:06.093012Z"
+    }
+   },
+   "source": [
+    "duckdb.sql(\"\"\"\n",
+    "SELECT *\n",
+    "FROM people\n",
+    "WHERE country = 'Germany'\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌────────────────┬─────────┐\n",
+       "│      name      │ country │\n",
+       "│    varchar     │ varchar │\n",
+       "├────────────────┼─────────┤\n",
+       "│ Michael Hunger │ Germany │\n",
+       "│ Michael Simons │ Germany │\n",
+       "└────────────────┴─────────┘"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 21
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:07.917641Z",
+     "start_time": "2025-04-06T08:54:07.903419Z"
+    }
+   },
+   "source": [
+    "params = {\"country\": \"Germany\"}\n",
+    "duckdb.execute(\"\"\"\n",
+    "SELECT *\n",
+    "FROM people\n",
+    "WHERE country <> $country\n",
+    "\"\"\", params).fetchdf()"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "           name        country\n",
+       "0  Mark Needham  Great Britain"
+      ],
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>name</th>\n",
+       "      <th>country</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Mark Needham</td>\n",
+       "      <td>Great Britain</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 22
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:09.716263Z",
+     "start_time": "2025-04-06T08:54:09.701767Z"
+    }
+   },
+   "source": [
+    "(duckdb.sql(\"FROM people\")\n",
+    "  .filter(\"country <> 'Germany'\")\n",
+    "  .show()\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "┌──────────────┬───────────────┐\n",
+      "│     name     │    country    │\n",
+      "│   varchar    │    varchar    │\n",
+      "├──────────────┼───────────────┤\n",
+      "│ Mark Needham │ Great Britain │\n",
+      "└──────────────┴───────────────┘\n",
+      "\n"
+     ]
+    }
+   ],
+   "execution_count": 23
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6.4.\t사용자 정의 함수"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:09.779231Z",
+     "start_time": "2025-04-06T08:54:09.765044Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select DISTINCT Region, length(Region) AS numChars\n",
+    "from population\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌─────────────────────────────────────┬──────────┐\n",
+       "│               Region                │ numChars │\n",
+       "│               varchar               │  int64   │\n",
+       "├─────────────────────────────────────┼──────────┤\n",
+       "│ EASTERN EUROPE                      │       35 │\n",
+       "│ NORTHERN AFRICA                     │       35 │\n",
+       "│ C.W. OF IND. STATES                 │       20 │\n",
+       "│ NORTHERN AMERICA                    │       35 │\n",
+       "│ SUB-SAHARAN AFRICA                  │       35 │\n",
+       "│ NEAR EAST                           │       35 │\n",
+       "│ OCEANIA                             │       35 │\n",
+       "│ WESTERN EUROPE                      │       35 │\n",
+       "│ BALTICS                             │       35 │\n",
+       "│ ASIA (EX. NEAR EAST)                │       29 │\n",
+       "│ LATIN AMER. & CARIB                 │       23 │\n",
+       "├─────────────────────────────────────┴──────────┤\n",
+       "│ 11 rows                              2 columns │\n",
+       "└────────────────────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 24
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:09.825586Z",
+     "start_time": "2025-04-06T08:54:09.817466Z"
+    }
+   },
+   "source": [
+    "def remove_spaces(field:str) -> str:\n",
+    "  if field:\n",
+    "    return field.lstrip().rstrip()\n",
+    "  else:\n",
+    "    return field"
+   ],
+   "outputs": [],
+   "execution_count": 25
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:11.653183Z",
+     "start_time": "2025-04-06T08:54:11.638144Z"
+    }
+   },
+   "source": [
+    "con.create_function('remove_spaces', remove_spaces)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<duckdb.duckdb.DuckDBPyConnection at 0x1ff264b1330>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 26
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:13.340418Z",
+     "start_time": "2025-04-06T08:54:13.309974Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT function_name, function_type, parameters, parameter_types, return_type\n",
+    "from duckdb_functions()\n",
+    "where function_name = 'remove_spaces'\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌───────────────┬───────────────┬────────────┬─────────────────┬─────────────┐\n",
+       "│ function_name │ function_type │ parameters │ parameter_types │ return_type │\n",
+       "│    varchar    │    varchar    │ varchar[]  │    varchar[]    │   varchar   │\n",
+       "├───────────────┼───────────────┼────────────┼─────────────────┼─────────────┤\n",
+       "│ remove_spaces │ scalar        │ [col0]     │ [VARCHAR]       │ VARCHAR     │\n",
+       "└───────────────┴───────────────┴────────────┴─────────────────┴─────────────┘"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 27
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:15.057903Z",
+     "start_time": "2025-04-06T08:54:15.044353Z"
+    }
+   },
+   "source": [
+    "con.sql(\"select length(remove_spaces(' foo '))\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌────────────────────────────────┐\n",
+       "│ length(remove_spaces(' foo ')) │\n",
+       "│             int64              │\n",
+       "├────────────────────────────────┤\n",
+       "│                              3 │\n",
+       "└────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 28
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:16.690993Z",
+     "start_time": "2025-04-06T08:54:16.676610Z"
+    }
+   },
+   "source": [
+    "con.remove_function('remove_spaces')"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<duckdb.duckdb.DuckDBPyConnection at 0x1ff264b1330>"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 29
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:54:18.452835Z",
+     "start_time": "2025-04-06T08:54:18.440356Z"
+    }
+   },
+   "source": [
+    "from duckdb.typing import *\n",
+    "\n",
+    "con.create_function(\n",
+    "  'remove_spaces',\n",
+    "  remove_spaces,\n",
+    "  [(VARCHAR)],\n",
+    "  VARCHAR\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<duckdb.duckdb.DuckDBPyConnection at 0x1ff264b1330>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 30
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:55:31.170045Z",
+     "start_time": "2025-04-06T08:55:31.148580Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT DISTINCT Region, length(Region) AS len1,\n",
+    "       remove_spaces(Region) AS cleanRegion,\n",
+    "       length(cleanRegion) AS len2\n",
+    "FROM population\n",
+    "\n",
+    "\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌─────────────────────────────────────┬───────┬──────────────────────┬───────┐\n",
+       "│               Region                │ len1  │     cleanRegion      │ len2  │\n",
+       "│               varchar               │ int64 │       varchar        │ int64 │\n",
+       "├─────────────────────────────────────┼───────┼──────────────────────┼───────┤\n",
+       "│ SUB-SAHARAN AFRICA                  │    35 │ SUB-SAHARAN AFRICA   │    18 │\n",
+       "│ NEAR EAST                           │    35 │ NEAR EAST            │     9 │\n",
+       "│ BALTICS                             │    35 │ BALTICS              │     7 │\n",
+       "│ NORTHERN AMERICA                    │    35 │ NORTHERN AMERICA     │    16 │\n",
+       "│ EASTERN EUROPE                      │    35 │ EASTERN EUROPE       │    14 │\n",
+       "│ C.W. OF IND. STATES                 │    20 │ C.W. OF IND. STATES  │    19 │\n",
+       "│ OCEANIA                             │    35 │ OCEANIA              │     7 │\n",
+       "│ WESTERN EUROPE                      │    35 │ WESTERN EUROPE       │    14 │\n",
+       "│ LATIN AMER. & CARIB                 │    23 │ LATIN AMER. & CARIB  │    19 │\n",
+       "│ ASIA (EX. NEAR EAST)                │    29 │ ASIA (EX. NEAR EAST) │    20 │\n",
+       "│ NORTHERN AFRICA                     │    35 │ NORTHERN AFRICA      │    15 │\n",
+       "├─────────────────────────────────────┴───────┴──────────────────────┴───────┤\n",
+       "│ 11 rows                                                          4 columns │\n",
+       "└────────────────────────────────────────────────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 33
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:39.121932Z",
+     "start_time": "2025-04-06T08:52:39.107441Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "UPDATE population\n",
+    "SET Region = remove_spaces(Region);\n",
+    "\"\"\")"
+   ],
+   "outputs": [],
+   "execution_count": 82
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:39.137718Z",
+     "start_time": "2025-04-06T08:52:39.126932Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "select DISTINCT Region, length(Region) AS numChars\n",
+    "from population\n",
+    "\"\"\")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌──────────────────────┬──────────┐\n",
+       "│        Region        │ numChars │\n",
+       "│       varchar        │  int64   │\n",
+       "├──────────────────────┼──────────┤\n",
+       "│ NORTHERN AMERICA     │       16 │\n",
+       "│ C.W. OF IND. STATES  │       19 │\n",
+       "│ EASTERN EUROPE       │       14 │\n",
+       "│ NORTHERN AFRICA      │       15 │\n",
+       "│ NEAR EAST            │        9 │\n",
+       "│ OCEANIA              │        7 │\n",
+       "│ ASIA (EX. NEAR EAST) │       20 │\n",
+       "│ BALTICS              │        7 │\n",
+       "│ WESTERN EUROPE       │       14 │\n",
+       "│ LATIN AMER. & CARIB  │       19 │\n",
+       "│ SUB-SAHARAN AFRICA   │       18 │\n",
+       "├──────────────────────┴──────────┤\n",
+       "│ 11 rows               2 columns │\n",
+       "└─────────────────────────────────┘"
+      ]
+     },
+     "execution_count": 83,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 83
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:40.837502Z",
+     "start_time": "2025-04-06T08:52:40.823237Z"
+    }
+   },
+   "source": [
+    "from duckdb.typing import *\n",
+    "import locale\n",
+    "\n",
+    "def convert_locale(field:str) -> float:\n",
+    "  locale.setlocale(locale.LC_ALL, 'de_DE')\n",
+    "  return locale.atof(field)"
+   ],
+   "outputs": [],
+   "execution_count": 84
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:42.554815Z",
+     "start_time": "2025-04-06T08:52:42.541356Z"
+    }
+   },
+   "source": [
+    "con.create_function('convert_locale', convert_locale)"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<duckdb.duckdb.DuckDBPyConnection at 0x216794b48b0>"
+      ]
+     },
+     "execution_count": 85,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 85
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:44.277296Z",
+     "start_time": "2025-04-06T08:52:44.263688Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "SELECT \"Coastline (coast/area ratio)\" AS coastline,\n",
+    "        convert_locale(coastline) as cleanCoastline,\n",
+    "        \"Pop. Density (per sq. mi.)\" as popDen,\n",
+    "        convert_locale(popDen) as cleanPopDen\n",
+    "FROM population\n",
+    "LIMIT 5\n",
+    "\"\"\")\n"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "┌───────────┬────────────────┬─────────┬─────────────┐\n",
+       "│ coastline │ cleanCoastline │ popDen  │ cleanPopDen │\n",
+       "│  varchar  │     double     │ varchar │   double    │\n",
+       "├───────────┼────────────────┼─────────┼─────────────┤\n",
+       "│ 0,00      │            0.0 │ 48,0    │        48.0 │\n",
+       "│ 1,26      │           1.26 │ 124,6   │       124.6 │\n",
+       "│ 0,04      │           0.04 │ 13,8    │        13.8 │\n",
+       "│ 58,29     │          58.29 │ 290,4   │       290.4 │\n",
+       "│ 0,00      │            0.0 │ 152,1   │       152.1 │\n",
+       "└───────────┴────────────────┴─────────┴─────────────┘"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 86
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:46.161288Z",
+     "start_time": "2025-04-06T08:52:46.147910Z"
+    }
+   },
+   "source": [
+    "con.sql(\"\"\"\n",
+    "ALTER TABLE population\n",
+    "ALTER \"Coastline (coast/area ratio)\"\n",
+    "SET DATA TYPE DOUBLE\n",
+    "USING\n",
+    "  convert_locale(\"Coastline (coast/area ratio)\")\n",
+    "\"\"\")"
+   ],
+   "outputs": [],
+   "execution_count": 87
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6.5.\tApache Arrow와 Polars의 상호운용성\n",
+    "```pip install polars pyarrow```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:48.037342Z",
+     "start_time": "2025-04-06T08:52:48.023839Z"
+    }
+   },
+   "source": [
+    "import polars\n",
+    "\n",
+    "population_table = con.table(\"population\")\n",
+    "\n",
+    "(population_table\n",
+    "   .limit(5)\n",
+    "   .pl()\n",
+    "  [[\"Country\", \"Region\", \"Population\"]]\n",
+    ")"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "shape: (5, 3)\n",
+       "┌─────────────────┬──────────────────────┬────────────┐\n",
+       "│ Country         ┆ Region               ┆ Population │\n",
+       "│ ---             ┆ ---                  ┆ ---        │\n",
+       "│ str             ┆ str                  ┆ i64        │\n",
+       "╞═════════════════╪══════════════════════╪════════════╡\n",
+       "│ Afghanistan     ┆ ASIA (EX. NEAR EAST) ┆ 31056997   │\n",
+       "│ Albania         ┆ EASTERN EUROPE       ┆ 3581655    │\n",
+       "│ Algeria         ┆ NORTHERN AFRICA      ┆ 32930091   │\n",
+       "│ American Samoa  ┆ OCEANIA              ┆ 57794      │\n",
+       "│ Andorra         ┆ WESTERN EUROPE       ┆ 71201      │\n",
+       "└─────────────────┴──────────────────────┴────────────┘"
+      ],
+      "text/html": [
+       "<div><style>\n",
+       ".dataframe > thead > tr,\n",
+       ".dataframe > tbody > tr {\n",
+       "  text-align: right;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       "</style>\n",
+       "<small>shape: (5, 3)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>Country</th><th>Region</th><th>Population</th></tr><tr><td>str</td><td>str</td><td>i64</td></tr></thead><tbody><tr><td>&quot;Afghanistan &quot;</td><td>&quot;ASIA (EX. NEAR EAST)&quot;</td><td>31056997</td></tr><tr><td>&quot;Albania &quot;</td><td>&quot;EASTERN EUROPE&quot;</td><td>3581655</td></tr><tr><td>&quot;Algeria &quot;</td><td>&quot;NORTHERN AFRICA&quot;</td><td>32930091</td></tr><tr><td>&quot;American Samoa &quot;</td><td>&quot;OCEANIA&quot;</td><td>57794</td></tr><tr><td>&quot;Andorra &quot;</td><td>&quot;WESTERN EUROPE&quot;</td><td>71201</td></tr></tbody></table></div>"
+      ]
+     },
+     "execution_count": 88,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 88
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:49.747173Z",
+     "start_time": "2025-04-06T08:52:49.732222Z"
+    }
+   },
+   "source": [
+    "arrow_table = population_table.to_arrow_table()"
+   ],
+   "outputs": [],
+   "execution_count": 89
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2025-04-06T08:52:49.793436Z",
+     "start_time": "2025-04-06T08:52:49.781374Z"
+    }
+   },
+   "source": [
+    "import pyarrow.compute as pc\n",
+    "\n",
+    "(arrow_table\n",
+    "  .filter(pc.field(\"Region\") == \"NEAR EAST\")\n",
+    "  .select([\"Country\", \"Region\", \"Population\"])\n",
+    "  .slice(length=5)\n",
+    ")\n"
+   ],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "pyarrow.Table\n",
+       "Country: string\n",
+       "Region: string\n",
+       "Population: int64\n",
+       "----\n",
+       "Country: [[\"Bahrain \",\"Cyprus \",\"Gaza Strip \",\"Iraq \",\"Israel \"]]\n",
+       "Region: [[\"NEAR EAST\",\"NEAR EAST\",\"NEAR EAST\",\"NEAR EAST\",\"NEAR EAST\"]]\n",
+       "Population: [[698585,784301,1428757,26783383,6352117]]"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "execution_count": 90
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ch08/dagster/atp/assets.py
+++ b/ch08/dagster/atp/assets.py
@@ -16,7 +16,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dagster/atp/assets.py
+++ b/ch08/dagster/atp/assets.py
@@ -16,7 +16,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dagster/step1/atp/assets.py
+++ b/ch08/dagster/step1/atp/assets.py
@@ -13,7 +13,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'VARCHAR', 

--- a/ch08/dagster/step1/atp/assets.py
+++ b/ch08/dagster/step1/atp/assets.py
@@ -13,7 +13,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'VARCHAR', 

--- a/ch08/dagster/step2/atp/assets.py
+++ b/ch08/dagster/step2/atp/assets.py
@@ -13,7 +13,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'VARCHAR', 

--- a/ch08/dagster/step2/atp/assets.py
+++ b/ch08/dagster/step2/atp/assets.py
@@ -13,7 +13,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'VARCHAR', 

--- a/ch08/dagster/step3/atp/assets.py
+++ b/ch08/dagster/step3/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dagster/step3/atp/assets.py
+++ b/ch08/dagster/step3/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dagster/step4_motherduck/atp/assets.py
+++ b/ch08/dagster/step4_motherduck/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dagster/step4_motherduck/atp/assets.py
+++ b/ch08/dagster/step4_motherduck/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute(""" 
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={
           'winner_seed': 'STRING', 

--- a/ch08/dbt/step1/models/atp/matches.sql
+++ b/ch08/dbt/step1/models/atp/matches.sql
@@ -13,6 +13,6 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date -- <.>
+    cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date -- <.>
 )
 FROM noWinLoss

--- a/ch08/dbt/step1/models/atp/matches.sql
+++ b/ch08/dbt/step1/models/atp/matches.sql
@@ -13,6 +13,6 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date -- <.>
+    cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date -- <.>
 )
 FROM noWinLoss

--- a/ch08/dbt/step2/models/atp/matches.sql
+++ b/ch08/dbt/step2/models/atp/matches.sql
@@ -13,6 +13,6 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date -- <.>
+    cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date -- <.>
 )
 FROM noWinLoss

--- a/ch08/dbt/step2/models/atp/matches.sql
+++ b/ch08/dbt/step2/models/atp/matches.sql
@@ -13,6 +13,6 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date -- <.>
+    cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date -- <.>
 )
 FROM noWinLoss

--- a/ch08/dbt/step3/models/atp/matches.sql
+++ b/ch08/dbt/step3/models/atp/matches.sql
@@ -13,7 +13,7 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date
+    cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date
 )
 FROM noWinLoss
 WHERE surface IS NOT NULL

--- a/ch08/dbt/step3/models/atp/matches.sql
+++ b/ch08/dbt/step3/models/atp/matches.sql
@@ -13,7 +13,7 @@ WITH noWinLoss AS (
 )
 
 SELECT * REPLACE (
-    cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date
+    cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date
 )
 FROM noWinLoss
 WHERE surface IS NOT NULL

--- a/ch08/dbt/step3/models/atp/schema.yml
+++ b/ch08/dbt/step3/models/atp/schema.yml
@@ -13,7 +13,7 @@ models:
         tests:
           - not_null
       - name: loser_id
-        description: "The ID of the winning player."
+        description: "The ID of the losing player."
         tests:
           - not_null
       - name: surface

--- a/ch09/atp/assets.py
+++ b/ch09/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute("""
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={'winner_seed': 'VARCHAR', 'loser_seed': 'VARCHAR'})
         """, [csv_files])

--- a/ch09/atp/assets.py
+++ b/ch09/atp/assets.py
@@ -15,7 +15,7 @@ def atp_matches_dataset(duckdb: DuckDBResource) -> None:
         conn.execute("""
         CREATE TABLE IF NOT EXISTS matches AS
         SELECT * REPLACE(
-            cast(strptime(tourney_date, '%Y%m%d') AS date) as tourney_date 
+            cast(strptime(cast(tourney_date AS VARCHAR), '%Y%m%d') AS date) as tourney_date 
         )
         FROM read_csv_auto($1, types={'winner_seed': 'VARCHAR', 'loser_seed': 'VARCHAR'})
         """, [csv_files])

--- a/ch10/convert_Badges.sh
+++ b/ch10/convert_Badges.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:    <row Id="1835163" UserId="724506" Name="Teacher" Date="2011-06-15T22:56:15.810" Class="3" TagBased="False" />
+
+7z e -so stackoverflow.com-Badges.7z | \
+xidel -se '//row/[(@Id|@UserId|@Name|@Date|@Class|@TagBased)]' - | \
+(echo "Id,UserId,Name,Date,Class,TagBased" &&
+jq -r '. | @csv') |
+gzip -9 > Badges.csv.gz

--- a/ch10/convert_Badges.sh
+++ b/ch10/convert_Badges.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Sample:    <row Id="1835163" UserId="724506" Name="Teacher" Date="2011-06-15T22:56:15.810" Class="3" TagBased="False" />
 
 7z e -so stackoverflow.com-Badges.7z | \
 xidel -se '//row/[(@Id|@UserId|@Name|@Date|@Class|@TagBased)]' - | \

--- a/ch10/convert_Comments.sh
+++ b/ch10/convert_Comments.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Sample:   <row Id="57515" PostId="37862" Score="0" Text="To other readers:, don't feel like you aren't smart enough to &#xA;a) test whatever built in generator you are using (there are lot of bad ones, unsuitable for simulation work) &#xA;b) learn enough about the existing generators to know which will suit your needs &#xA;c) learn to best use results" CreationDate="2008-10-05T14:15:48.240" UserId="279" />
 
 7z e -so stackoverflow.com-Comments.7z | \
 xidel -se '//row/[(@Id|@PostId|@Score|@Text|@CreationDate|@UserId)]' - | \

--- a/ch10/convert_Comments.sh
+++ b/ch10/convert_Comments.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:   <row Id="57515" PostId="37862" Score="0" Text="To other readers:, don't feel like you aren't smart enough to &#xA;a) test whatever built in generator you are using (there are lot of bad ones, unsuitable for simulation work) &#xA;b) learn enough about the existing generators to know which will suit your needs &#xA;c) learn to best use results" CreationDate="2008-10-05T14:15:48.240" UserId="279" />
+
+7z e -so stackoverflow.com-Comments.7z | \
+xidel -se '//row/[(@Id|@PostId|@Score|@Text|@CreationDate|@UserId)]' - | \
+(echo "Id,PostId,Score,Text,CreationDate,UserId" &&
+jq -r '. | @csv') |
+gzip -9 > Comments.csv.gz

--- a/ch10/convert_PostLinks.sh
+++ b/ch10/convert_PostLinks.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:   <row Id="816331943" CreationDate="2013-07-28T15:03:46.380" PostId="17908846" RelatedPostId="1112665" LinkTypeId="1" />
+
+7z e -so stackoverflow.com-PostLinks.7z | \
+xidel -se '//row/[(@Id|@CreationDate|@PostId|@RelatedPostId|@LinkTypeId)]' - | \
+(echo "Id,CreationDate,PostId,RelatedPostId,LinkTypeId" &&
+jq -r '. | @csv') |
+gzip -9 > PostLinks.csv.gz

--- a/ch10/convert_PostLinks.sh
+++ b/ch10/convert_PostLinks.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Sample:   <row Id="816331943" CreationDate="2013-07-28T15:03:46.380" PostId="17908846" RelatedPostId="1112665" LinkTypeId="1" />
 
 7z e -so stackoverflow.com-PostLinks.7z | \
 xidel -se '//row/[(@Id|@CreationDate|@PostId|@RelatedPostId|@LinkTypeId)]' - | \

--- a/ch10/convert_Posts.sh
+++ b/ch10/convert_Posts.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:  <row Id="25679" PostTypeId="2" ParentId="6113" CreationDate="2008-08-25T05:12:51.047" Score="3" Body="&lt;p&gt;Just assume that the bad guys WILL get the credentials out of your config file.  This means that they'd be able to login to your database and do whatever that user is capable of.  So just make sure that user can't do anything bad like access the tables directly.  Make that user only capable of executing certain stored procedures and you'll be in better shape.  This is one place that sprocs shine.&lt;/p&gt;&#xA;" OwnerUserId="1975" OwnerDisplayName="Webjedi" LastActivityDate="2008-08-25T05:12:51.047" CommentCount="1" ContentLicense="CC BY-SA 2.5" />
+
+7z e -so stackoverflow.com-Posts.7z | \
+xidel -se '//row/[(@Id|@PostTypeId|@AcceptedAnswerId|@CreationDate|@Score|@ViewCount|@Body|@OwnerUserId|@OwnerDisplayName|@LastActivityDate|@CommentCount|@ContentLicense)]' - | \
+(echo "Id,PostTypeId,AcceptedAnswerId,CreationDate,Score,ViewCount,Body,OwnerUserId,OwnerDisplayName,LastActivityDate,CommentCount,ContentLicense" &&
+jq -r '. | @csv') |
+gzip -9 > Posts.csv.gz

--- a/ch10/convert_Posts.sh
+++ b/ch10/convert_Posts.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-# Sample:  <row Id="25679" PostTypeId="2" ParentId="6113" CreationDate="2008-08-25T05:12:51.047" Score="3" Body="&lt;p&gt;Just assume that the bad guys WILL get the credentials out of your config file.  This means that they'd be able to login to your database and do whatever that user is capable of.  So just make sure that user can't do anything bad like access the tables directly.  Make that user only capable of executing certain stored procedures and you'll be in better shape.  This is one place that sprocs shine.&lt;/p&gt;&#xA;" OwnerUserId="1975" OwnerDisplayName="Webjedi" LastActivityDate="2008-08-25T05:12:51.047" CommentCount="1" ContentLicense="CC BY-SA 2.5" />
 
 7z e -so stackoverflow.com-Posts.7z | \
-xidel -se '//row/[(@Id|@PostTypeId|@AcceptedAnswerId|@CreationDate|@Score|@ViewCount|@Body|@OwnerUserId|@OwnerDisplayName|@LastActivityDate|@CommentCount|@ContentLicense)]' - | \
-(echo "Id,PostTypeId,AcceptedAnswerId,CreationDate,Score,ViewCount,Body,OwnerUserId,OwnerDisplayName,LastActivityDate,CommentCount,ContentLicense" &&
-jq -r '. | @csv') |
+xidel -se '//row/[(@Id|@PostTypeId|@AcceptedAnswerId|@CreationDate|@Score|@ViewCount|@Body|@OwnerUserId|@LastEditorUserId|@LastEditorDisplayName|@LastEditDate|@LastActivityDate|@Title|@Tags|@AnswerCount|@CommentCount|@FavoriteCount|@CommunityOwnedDate|@ContentLicense)]' - | \
+(echo "Id,PostTypeId,AcceptedAnswerId,CreationDate,Score,ViewCount,Body,OwnerUserId,LastEditorUserId,LastEditorDisplayName,LastEditDate,LastActivityDate,Title,Tags,AnswerCount,CommentCount,FavoriteCount,CommunityOwnedDate,ContentLicense" &&jq -r '. | @csv') |
 gzip -9 > Posts.csv.gz

--- a/ch10/convert_Posts.sh
+++ b/ch10/convert_Posts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 7z e -so stackoverflow.com-Posts.7z | \
-xidel -se '//row/[(@Id|@PostTypeId|@AcceptedAnswerId|@CreationDate|@Score|@ViewCount|@Body|@OwnerUserId|@LastEditorUserId|@LastEditorDisplayName|@LastEditDate|@LastActivityDate|@Title|@Tags|@AnswerCount|@CommentCount|@FavoriteCount|@CommunityOwnedDate|@ContentLicense)]' - | \
-(echo "Id,PostTypeId,AcceptedAnswerId,CreationDate,Score,ViewCount,Body,OwnerUserId,LastEditorUserId,LastEditorDisplayName,LastEditDate,LastActivityDate,Title,Tags,AnswerCount,CommentCount,FavoriteCount,CommunityOwnedDate,ContentLicense" &&jq -r '. | @csv') |
+xidel -se '//row/[(@Id|@PostTypeId|@AcceptedAnswerId|@ParentId|@CreationDate|@Score|@ViewCount|@Body|@OwnerUserId|@LastEditorUserId|@LastEditorDisplayName|@LastEditDate|@LastActivityDate|@Title|@Tags|@AnswerCount|@CommentCount|@FavoriteCount|@CommunityOwnedDate|@ContentLicense)]' - | \
+(echo "Id,PostTypeId,AcceptedAnswerId,ParentId,CreationDate,Score,ViewCount,Body,OwnerUserId,LastEditorUserId,LastEditorDisplayName,LastEditDate,LastActivityDate,Title,Tags,AnswerCount,CommentCount,FavoriteCount,CommunityOwnedDate,ContentLicense" &&jq -r '. | @csv') |
 gzip -9 > Posts.csv.gz

--- a/ch10/convert_Tags.sh
+++ b/ch10/convert_Tags.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# Sample:   <row Id="139962" TagName="amazon-forecast" Count="37" ExcerptPostId="57755281" WikiPostId="57755280" />
 
 7z e -so stackoverflow.com-Tags.7z | \
 xidel -se '//row/[(@Id|@TagName|@Count|@ExcerptPostId|@WikiPostId)]' - | \

--- a/ch10/convert_Tags.sh
+++ b/ch10/convert_Tags.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:   <row Id="139962" TagName="amazon-forecast" Count="37" ExcerptPostId="57755281" WikiPostId="57755280" />
+
+7z e -so stackoverflow.com-Tags.7z | \
+xidel -se '//row/[(@Id|@TagName|@Count|@ExcerptPostId|@WikiPostId)]' - | \
+(echo "Id,TagName,Count,ExcerptPostId,WikiPostId" &&
+jq -r '. | @csv') |
+gzip -9 > Tags.csv.gz

--- a/ch10/convert_Users.sh
+++ b/ch10/convert_Users.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Sample:      <row Id="44562" Reputation="74770" CreationDate="2008-12-09T11:04:10.673" DisplayName="soulmerge" LastAccessDate="2024-04-04T12:24:33.967" WebsiteUrl="https://atesman.at" AboutMe="" Views="2405" UpVotes="2725" DownVotes="186" AccountId="19131" />
+
+7z e -so stackoverflow.com-Users.7z | \
+xidel -se '//row/[(@Id|@Reputation|@CreationDate|@DisplayName|@LastAccessDate|@WebsiteUrl|@AboutMe|@Views|@UpVotes|@DownVotes|@AccountId)]' - | \
+(echo "Id,Reputation,CreationDate,DisplayName,LastAccessDate,WebsiteUrl,AboutMe,Views,UpVotes,DownVotes,AccountId" &&
+jq -r '. | @csv') |
+gzip -9 > Users.csv.gz
+
+
+
+

--- a/ch10/convert_Users.sh
+++ b/ch10/convert_Users.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
-# Sample:      <row Id="44562" Reputation="74770" CreationDate="2008-12-09T11:04:10.673" DisplayName="soulmerge" LastAccessDate="2024-04-04T12:24:33.967" WebsiteUrl="https://atesman.at" AboutMe="" Views="2405" UpVotes="2725" DownVotes="186" AccountId="19131" />
 
 7z e -so stackoverflow.com-Users.7z | \
-xidel -se '//row/[(@Id|@Reputation|@CreationDate|@DisplayName|@LastAccessDate|@WebsiteUrl|@AboutMe|@Views|@UpVotes|@DownVotes|@AccountId)]' - | \
-(echo "Id,Reputation,CreationDate,DisplayName,LastAccessDate,WebsiteUrl,AboutMe,Views,UpVotes,DownVotes,AccountId" &&
+xidel -se '//row/[(@Id|@Reputation|@CreationDate|@DisplayName|@LastAccessDate|@AboutMe|@Views|@UpVotes|@DownVotes|@WebsiteUrl|@Location|@AccountId)]' - | \
+(echo "Id,Reputation,CreationDate,DisplayName,LastAccessDate,AboutMe,Views,UpVotes,DownVotes,WebsiteUrl,Location,AccountId" &&
 jq -r '. | @csv') |
 gzip -9 > Users.csv.gz
-
-
-
-

--- a/ch10/convert_Votes.sh
+++ b/ch10/convert_Votes.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# Sample:   <row Id="7302" PostId="3061" VoteTypeId="2" CreationDate="2008-08-06T00:00:00.000" />
 
 7z e -so stackoverflow.com-Votes.7z | \
-xidel -se '//row/[(@Id|@PostId|@VoteTypeId|@CreationDate)]' - | \
-(echo "Id,PostId,VoteTypeId,CreationDate" &&
+xidel -se '//row/[(@Id|@PostId|@VoteTypeId|@CreationDate|@UserId|@BountyAmount)]' - | \
+(echo "Id,PostId,VoteTypeId,CreationDate,UserId,BountyAmount" &&
 jq -r '. | @csv') |
 gzip -9 > Votes.csv.gz

--- a/ch10/convert_Votes.sh
+++ b/ch10/convert_Votes.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Sample:   <row Id="7302" PostId="3061" VoteTypeId="2" CreationDate="2008-08-06T00:00:00.000" />
+
+7z e -so stackoverflow.com-Votes.7z | \
+xidel -se '//row/[(@Id|@PostId|@VoteTypeId|@CreationDate)]' - | \
+(echo "Id,PostId,VoteTypeId,CreationDate" &&
+jq -r '. | @csv') |
+gzip -9 > Votes.csv.gz


### PR DESCRIPTION
# 1. Fix: Correct `tourney_date` casting in SQL query

- Updated `tourney_date` casting logic to ensure compatibility with VARCHAR type.
- Changed `cast(strptime(tourney_date, '%Y%m%d') AS date)` to `cast(strptime(tourney_date::VARCHAR, '%Y%m%d') AS date)`.
- This fix resolves potential issues with type mismatches during query execution.

Tested with `duckdb` v1.1.3, `dbt` v1.9.1 and `dagster` v1.9.9.

This is the same issue as #2.

# 2. Add: Chapter 10's Data Dump and Extraction Code
It's related to #6 issue.